### PR TITLE
Changing FlatButton -> TextButton

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,9 +50,11 @@ class _QuizPageState extends State<QuizPage> {
         Expanded(
           child: Padding(
             padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              textColor: Colors.white,
-              color: Colors.green,
+            child: TextButton(
+              style: TextButton.styleFrom(
+                foregroundColor: Colors.white,
+                backgroundColor: Colors.green,
+              ),
               child: Text(
                 'True',
                 style: TextStyle(
@@ -69,8 +71,10 @@ class _QuizPageState extends State<QuizPage> {
         Expanded(
           child: Padding(
             padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              color: Colors.red,
+            child: TextButton(
+               style: TextButton.styleFrom(
+                  backgroundColor: Colors.red
+               ),
               child: Text(
                 'False',
                 style: TextStyle(


### PR DESCRIPTION
The FlatButton class is removed from Flutter and replaced by TextButton class instead. The syntax of styling of the button too has changed. So, I have changed it accordingly.